### PR TITLE
Pin net-ssh to 2.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem 'veewee'
+gem 'net-ssh', '2.9.2'
 


### PR DESCRIPTION
Recent builds of https://ci.openmicroscopy.org/view/Failing/job/VIRTUALBOX-baseimage/ have been failing. The issue seems to be had elsewhere: https://github.com/capistrano/sshkit/issues/269

This PR pins the version of net-ssh to 2.9.2. I've updated the job to perform a merge build and kicked off a build to test:

  https://ci.openmicroscopy.org/view/Failing/job/VIRTUALBOX-baseimage/609