### PR TITLE
Installing the JDK rather than the JRE

### DIFF
--- a/definitions/Debian-7.1.0-amd64-omerobase/omero_deps.sh
+++ b/definitions/Debian-7.1.0-amd64-omerobase/omero_deps.sh
@@ -4,7 +4,7 @@ apt-get -y install unzip git
 # OMERO requirements
 apt-get -y install \
     python-{imaging,matplotlib,numpy,pip,scipy,tables,virtualenv} \
-    openjdk-7-jre-headless \
+    openjdk-7-jdk \
     ice34-services python-zeroc-ice \
     postgresql \
     nginx \

--- a/definitions/Debian-7.4.0-amd64-omerobase/omero_deps.sh
+++ b/definitions/Debian-7.4.0-amd64-omerobase/omero_deps.sh
@@ -4,7 +4,7 @@ apt-get -y install unzip git
 # OMERO requirements
 apt-get -y install \
     python-{imaging,matplotlib,numpy,pip,scipy,tables,virtualenv} \
-    openjdk-7-jre-headless \
+    openjdk-7-jdk \
     ice34-services python-zeroc-ice \
     postgresql \
     nginx \

--- a/definitions/Debian-7.6.0-amd64-omerobase/omero_deps.sh
+++ b/definitions/Debian-7.6.0-amd64-omerobase/omero_deps.sh
@@ -4,7 +4,7 @@ apt-get -y install unzip git
 # OMERO requirements
 apt-get -y install \
     python-{imaging,matplotlib,numpy,pip,scipy,tables,virtualenv} \
-    openjdk-7-jre-headless \
+    openjdk-7-jdk \
     ice34-services python-zeroc-ice \
     postgresql \
     nginx \

--- a/definitions/Debian-7.7.0-amd64-omerobase/omero_deps.sh
+++ b/definitions/Debian-7.7.0-amd64-omerobase/omero_deps.sh
@@ -4,7 +4,7 @@ apt-get -y install unzip git
 # OMERO requirements
 apt-get -y install \
     python-{imaging,matplotlib,numpy,pip,scipy,tables,virtualenv} \
-    openjdk-7-jre-headless \
+    openjdk-7-jdk \
     ice34-services python-zeroc-ice \
     postgresql \
     nginx \

--- a/definitions/ubuntu-14.04-amd64-omerobase/omero_deps.sh
+++ b/definitions/ubuntu-14.04-amd64-omerobase/omero_deps.sh
@@ -10,7 +10,7 @@ apt-get -y install \
     python-scipy \
     python-tables \
     python-virtualenv \
-    openjdk-7-jre-headless \
+    openjdk-7-jdk \
     ice-services python-zeroc-ice \
     postgresql \
     nginx \


### PR DESCRIPTION
A recent blog post described slow import speeds. In
an attempt to get a stacktrace of the hanging code,
we installed the JDK after which it was no longer
possible to reproduce the hang. Installing the JDK
now across the board with the help that this helps.

See: https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7885