### PR TITLE
Pin fog-google dependency to 0.0.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem 'veewee'
 gem 'net-ssh', '2.9.2'
+gem 'fog-google' ,'0.0.9'
 


### PR DESCRIPTION
Most recent release of fog-google (0.1.1) requires Ruby >= 2.0. This commit
should pin the dependency version to prevent the VIRTUALBOX-baseimage job from
failing.

/cc @manics @joshmoore 